### PR TITLE
Fix to $.param is not a function error in #10

### DIFF
--- a/build/jQueryShim.js
+++ b/build/jQueryShim.js
@@ -85,8 +85,7 @@ var ajax = function ajax(options) {
       return request.abort(reason);
     },
     xhrSupported: function () {
-      var xhrSupported = xhr();
-      return !!xhrSupported && "withCredentials" in xhrSupported;
+      return !!xhr();
     }()
   };
 };
@@ -107,6 +106,6 @@ module.exports = jQueryDeferred.extend(jqueryFunction, jQueryDeferred, {
     return [].slice.call(arr, 0);
   },
   support: {
-    cors: ajax.xhrSupported
+    cors: ajax.xhrSupported && "withCredentials" in xhrSupported
   }
 });

--- a/build/jQueryShim.js
+++ b/build/jQueryShim.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const jQueryDeferred = require('jquery-deferred')
-const jQueryParam = require('jquery-param')
+const jQueryDeferred = require('jquery-deferred');
+const jQueryParam = require('jquery-param');
 
 const jqueryFunction = function(subject) {
   let events = subject.events || {};

--- a/build/jQueryShim.js
+++ b/build/jQueryShim.js
@@ -1,47 +1,42 @@
 'use strict';
 
-var jQueryDeferred = require('jquery-deferred');
+const jQueryDeferred = require('jquery-deferred')
+const jQueryParam = require('jquery-param')
 
-var jqueryFunction = function jqueryFunction(subject) {
-  var events = subject.events || {};
+const jqueryFunction = function(subject) {
+  let events = subject.events || {};
 
-  if (subject && subject === subject.window) return {
-    0: subject,
-    load: function load(handler) {
-      return subject.addEventListener('load', handler, false);
-    },
-    bind: function bind(event, handler) {
-      return subject.addEventListener(event, handler, false);
-    },
-    unbind: function unbind(event, handler) {
-      return subject.removeEventListener(event, handler, false);
-    }
-  };
+  if (subject && subject === subject.window)
+    return {
+      0: subject,
+      load: (handler) => subject.addEventListener('load', handler, false),
+      bind: (event, handler) => subject.addEventListener(event, handler, false),
+      unbind: (event, handler) => subject.removeEventListener(event, handler, false)
+    };
 
   return {
     0: subject,
 
-    unbind: function unbind(event, handler) {
-      var handlers = events[event] || [];
+    unbind(event, handler) {
+      let handlers = events[event] || [];
 
       if (handler) {
-        var idx = handlers.indexOf(handler);
+        let idx = handlers.indexOf(handler);
         if (idx !== -1) handlers.splice(idx, 1);
       } else handlers = [];
 
       events[event] = handlers;
       subject.events = events;
+
     },
-    bind: function bind(event, handler) {
-      var current = events[event] || [];
+    bind(event, handler) {
+      let current = events[event] || [];
       events[event] = current.concat(handler);
       subject.events = events;
     },
-    triggerHandler: function triggerHandler(event, args) {
-      var _this = this;
-
-      var handlers = events[event] || [];
-      handlers.forEach(function (fn) {
+    triggerHandler(event, args) {
+      let handlers = events[event] || [];
+      handlers.forEach(fn => {
         if (args && args[0] && args[0].type === undefined) {
           args = [{
             type: event
@@ -50,21 +45,21 @@ var jqueryFunction = function jqueryFunction(subject) {
           args = args || [];
         }
 
-        fn.apply(_this, args);
+        fn.apply(this, args);
       });
     }
   };
 };
 
-var xhr = function xhr() {
+const xhr = function() {
   try {
     return new window.XMLHttpRequest();
-  } catch (e) {}
+  } catch (e) { }
 };
 
-var ajax = function ajax(options) {
-  var request = xhr();
-  request.onreadystatechange = function () {
+const ajax = function(options) {
+  const request = xhr();
+  request.onreadystatechange = () => {
     if (request.readyState !== 4) {
       return;
     }
@@ -79,34 +74,31 @@ var ajax = function ajax(options) {
   request.open(options.type, options.url);
   request.setRequestHeader('content-type', options.contentType);
 
-  request.send(options.data.data && 'data=' + options.data.data);
+  request.send(options.data.data && `data=${options.data.data}`);
 
   return {
-    abort: function abort(reason) {
+    abort: function(reason) {
       return request.abort(reason);
     }
   };
 };
 
-module.exports = jQueryDeferred.extend(jqueryFunction, jQueryDeferred, {
-  defaultAjaxHeaders: null,
-  ajax: ajax,
-  inArray: function inArray(arr, item) {
-    return arr.indexOf(item) !== -1;
-  },
-  trim: function trim(str) {
-    return str && str.trim();
-  },
-  isEmptyObject: function isEmptyObject(obj) {
-    return !obj || Object.keys(obj).length === 0;
-  },
-  makeArray: function makeArray(arr) {
-    return [].slice.call(arr, 0);
-  },
-  support: {
-    cors: function () {
-      var xhrObj = xhr();
-      return !!xhrObj && "withCredentials" in xhrObj;
-    }()
-  }
-});
+module.exports = jQueryDeferred.extend(
+  jqueryFunction,
+  jQueryDeferred,
+  {
+    defaultAjaxHeaders: null,
+    ajax: ajax,
+    inArray: (arr,item) => arr.indexOf(item) !== -1,
+    trim: str => str && str.trim(),
+    isEmptyObject: obj => !obj || Object.keys(obj).length === 0,
+    makeArray: arr => [].slice.call(arr,0),
+    param: obj => jQueryParam(obj),
+    support: {
+      cors: (function() {
+        const xhrObj = xhr();
+        return !!xhrObj && ("withCredentials" in xhrObj);
+      })()
+    }
+  })
+  

--- a/build/jQueryShim.js
+++ b/build/jQueryShim.js
@@ -56,12 +56,13 @@ var jqueryFunction = function jqueryFunction(subject) {
   };
 };
 
+var xhr = function xhr() {
+  try {
+    return new window.XMLHttpRequest();
+  } catch (e) {}
+};
+
 var ajax = function ajax(options) {
-  var xhr = function xhr() {
-    try {
-      return new window.XMLHttpRequest();
-    } catch (e) {}
-  };
   var request = xhr();
   request.onreadystatechange = function () {
     if (request.readyState !== 4) {
@@ -83,11 +84,7 @@ var ajax = function ajax(options) {
   return {
     abort: function abort(reason) {
       return request.abort(reason);
-    },
-    xhrSupported: function () {
-      var xhrSupported = xhr();
-      return !!xhrSupported && "withCredentials" in xhrSupported;
-    }()
+    }
   };
 };
 
@@ -107,6 +104,9 @@ module.exports = jQueryDeferred.extend(jqueryFunction, jQueryDeferred, {
     return [].slice.call(arr, 0);
   },
   support: {
-    cors: ajax.xhrSupported
+    cors: function () {
+      var xhrObj = xhr();
+      return !!xhrObj && "withCredentials" in xhrObj;
+    }()
   }
 });

--- a/build/jQueryShim.js
+++ b/build/jQueryShim.js
@@ -57,7 +57,12 @@ var jqueryFunction = function jqueryFunction(subject) {
 };
 
 var ajax = function ajax(options) {
-  var request = new XMLHttpRequest();
+  var xhr = function xhr() {
+    try {
+      return new window.XMLHttpRequest();
+    } catch (e) {}
+  };
+  var request = xhr();
   request.onreadystatechange = function () {
     if (request.readyState !== 4) {
       return;
@@ -78,7 +83,11 @@ var ajax = function ajax(options) {
   return {
     abort: function abort(reason) {
       return request.abort(reason);
-    }
+    },
+    xhrSupported: function () {
+      var xhrSupported = xhr();
+      return !!xhrSupported && "withCredentials" in xhrSupported;
+    }()
   };
 };
 
@@ -98,6 +107,6 @@ module.exports = jQueryDeferred.extend(jqueryFunction, jQueryDeferred, {
     return [].slice.call(arr, 0);
   },
   support: {
-    cors: false
+    cors: ajax.xhrSupported
   }
 });

--- a/build/signalR.js
+++ b/build/signalR.js
@@ -1,12 +1,6 @@
 'use strict';
 
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
-var jQueryShim = require('./jQueryShim');
+const jQueryShim = require('./jQueryShim');
 
 /* jquery.signalR.core.js */
 /*global window:false */
@@ -51,101 +45,105 @@ var jQueryShim = require('./jQueryShim');
         reconnectWindowTimeout: "The client has been inactive since {0} and it has exceeded the inactivity timeout of {1} ms. Stopping the connection."
     };
 
-    if (typeof $ !== "function") {
+    if (typeof ($) !== "function") {
         // no jQuery!
         throw new Error(resources.nojQuery);
     }
 
-    var _signalR,
+    var signalR,
         _connection,
-        _pageLoaded = window.document.readyState === "complete",
+        _pageLoaded = (window.document.readyState === "complete"),
         _pageWindow = $(window),
         _negotiateAbortText = "__Negotiate Aborted__",
         events = {
-        onStart: "onStart",
-        onStarting: "onStarting",
-        onReceived: "onReceived",
-        onError: "onError",
-        onConnectionSlow: "onConnectionSlow",
-        onReconnecting: "onReconnecting",
-        onReconnect: "onReconnect",
-        onStateChanged: "onStateChanged",
-        onDisconnect: "onDisconnect"
-    },
+            onStart: "onStart",
+            onStarting: "onStarting",
+            onReceived: "onReceived",
+            onError: "onError",
+            onConnectionSlow: "onConnectionSlow",
+            onReconnecting: "onReconnecting",
+            onReconnect: "onReconnect",
+            onStateChanged: "onStateChanged",
+            onDisconnect: "onDisconnect"
+        },
         ajaxDefaults = {
-        processData: true,
-        timeout: null,
-        async: true,
-        global: false,
-        cache: false
-    },
-        _log = function _log(msg, logging) {
-        if (logging === false) {
-            return;
-        }
-        var m;
-        if (typeof window.console === "undefined") {
-            return;
-        }
-        m = "[" + new Date().toTimeString() + "] SignalR: " + msg;
-        if (window.console.debug) {
-            window.console.debug(m);
-        } else if (window.console.log) {
-            window.console.log(m);
-        }
-    },
-        changeState = function changeState(connection, expectedState, newState) {
-        if (expectedState === connection.state) {
-            connection.state = newState;
+            processData: true,
+            timeout: null,
+            async: true,
+            global: false,
+            cache: false
+        },
+        log = function (msg, logging) {
+            if (logging === false) {
+                return;
+            }
+            var m;
+            if (typeof (window.console) === "undefined") {
+                return;
+            }
+            m = "[" + new Date().toTimeString() + "] SignalR: " + msg;
+            if (window.console.debug) {
+                window.console.debug(m);
+            } else if (window.console.log) {
+                window.console.log(m);
+            }
+        },
 
-            $(connection).triggerHandler(events.onStateChanged, [{ oldState: expectedState, newState: newState }]);
-            return true;
-        }
+        changeState = function (connection, expectedState, newState) {
+            if (expectedState === connection.state) {
+                connection.state = newState;
 
-        return false;
-    },
-        isDisconnecting = function isDisconnecting(connection) {
-        return connection.state === _signalR.connectionState.disconnected;
-    },
-        supportsKeepAlive = function supportsKeepAlive(connection) {
-        return connection._.keepAliveData.activated && connection.transport.supportsKeepAlive(connection);
-    },
-        configureStopReconnectingTimeout = function configureStopReconnectingTimeout(connection) {
-        var stopReconnectingTimeout, onReconnectTimeout;
+                $(connection).triggerHandler(events.onStateChanged, [{ oldState: expectedState, newState: newState }]);
+                return true;
+            }
 
-        // Check if this connection has already been configured to stop reconnecting after a specified timeout.
-        // Without this check if a connection is stopped then started events will be bound multiple times.
-        if (!connection._.configuredStopReconnectingTimeout) {
-            onReconnectTimeout = function onReconnectTimeout(connection) {
-                var message = _signalR._.format(_signalR.resources.reconnectTimeout, connection.disconnectTimeout);
-                connection.log(message);
-                $(connection).triggerHandler(events.onError, [_signalR._.error(message, /* source */"TimeoutException")]);
-                connection.stop( /* async */false, /* notifyServer */false);
-            };
+            return false;
+        },
 
-            connection.reconnecting(function () {
-                var connection = this;
+        isDisconnecting = function (connection) {
+            return connection.state === signalR.connectionState.disconnected;
+        },
 
-                // Guard against state changing in a previous user defined even handler
-                if (connection.state === _signalR.connectionState.reconnecting) {
-                    stopReconnectingTimeout = window.setTimeout(function () {
-                        onReconnectTimeout(connection);
-                    }, connection.disconnectTimeout);
-                }
-            });
+        supportsKeepAlive = function (connection) {
+            return connection._.keepAliveData.activated &&
+                   connection.transport.supportsKeepAlive(connection);
+        },
 
-            connection.stateChanged(function (data) {
-                if (data.oldState === _signalR.connectionState.reconnecting) {
-                    // Clear the pending reconnect timeout check
-                    window.clearTimeout(stopReconnectingTimeout);
-                }
-            });
+        configureStopReconnectingTimeout = function (connection) {
+            var stopReconnectingTimeout,
+                onReconnectTimeout;
 
-            connection._.configuredStopReconnectingTimeout = true;
-        }
-    };
+            // Check if this connection has already been configured to stop reconnecting after a specified timeout.
+            // Without this check if a connection is stopped then started events will be bound multiple times.
+            if (!connection._.configuredStopReconnectingTimeout) {
+                onReconnectTimeout = function (connection) {
+                    var message = signalR._.format(signalR.resources.reconnectTimeout, connection.disconnectTimeout);
+                    connection.log(message);
+                    $(connection).triggerHandler(events.onError, [signalR._.error(message, /* source */ "TimeoutException")]);
+                    connection.stop(/* async */ false, /* notifyServer */ false);
+                };
 
-    _signalR = function signalR(url, qs, logging) {
+                connection.reconnecting(function () {
+                    var connection = this;
+
+                    // Guard against state changing in a previous user defined even handler
+                    if (connection.state === signalR.connectionState.reconnecting) {
+                        stopReconnectingTimeout = window.setTimeout(function () { onReconnectTimeout(connection); }, connection.disconnectTimeout);
+                    }
+                });
+
+                connection.stateChanged(function (data) {
+                    if (data.oldState === signalR.connectionState.reconnecting) {
+                        // Clear the pending reconnect timeout check
+                        window.clearTimeout(stopReconnectingTimeout);
+                    }
+                });
+
+                connection._.configuredStopReconnectingTimeout = true;
+            }
+        };
+
+    signalR = function (url, qs, logging) {
         /// <summary>Creates a new SignalR connection for the given url</summary>
         /// <param name="url" type="String">The URL of the long polling endpoint</param>
         /// <param name="qs" type="Object">
@@ -158,14 +156,15 @@ var jQueryShim = require('./jQueryShim');
         ///     console/log. Defaults to false.
         /// </param>
 
-        return new _signalR.fn.init(url, qs, logging);
+        return new signalR.fn.init(url, qs, logging);
     };
 
-    _signalR._ = {
+    signalR._ = {
         defaultContentType: "application/x-www-form-urlencoded; charset=UTF-8",
 
-        ieVersion: function () {
-            var version, matches;
+        ieVersion: (function () {
+            var version,
+                matches;
 
             if (window.navigator.appName === 'Microsoft Internet Explorer') {
                 // Check if the user agent has the pattern "MSIE (one or more numbers).(one or more numbers)";
@@ -178,9 +177,9 @@ var jQueryShim = require('./jQueryShim');
 
             // undefined value means not IE
             return version;
-        }(),
+        })(),
 
-        error: function error(message, source, context) {
+        error: function (message, source, context) {
             var e = new Error(message);
             e.source = source;
 
@@ -191,13 +190,13 @@ var jQueryShim = require('./jQueryShim');
             return e;
         },
 
-        transportError: function transportError(message, transport, source, context) {
+        transportError: function (message, transport, source, context) {
             var e = this.error(message, source, context);
             e.transport = transport ? transport.name : undefined;
             return e;
         },
 
-        format: function format() {
+        format: function () {
             /// <summary>Usage: format("Hi {0}, you are {1}!", "Foo", 100) </summary>
             var s = arguments[0];
             for (var i = 0; i < arguments.length - 1; i++) {
@@ -206,7 +205,7 @@ var jQueryShim = require('./jQueryShim');
             return s;
         },
 
-        firefoxMajorVersion: function firefoxMajorVersion(userAgent) {
+        firefoxMajorVersion: function (userAgent) {
             // Firefox user agents: http://useragentstring.com/pages/Firefox/
             var matches = userAgent.match(/Firefox\/(\d+)/);
             if (!matches || !matches.length || matches.length < 2) {
@@ -215,39 +214,39 @@ var jQueryShim = require('./jQueryShim');
             return parseInt(matches[1], 10 /* radix */);
         },
 
-        configurePingInterval: function configurePingInterval(connection) {
+        configurePingInterval: function (connection) {
             var config = connection._.config,
-                onFail = function onFail(error) {
-                $(connection).triggerHandler(events.onError, [error]);
-            };
+                onFail = function (error) {
+                    $(connection).triggerHandler(events.onError, [error]);
+                };
 
             if (config && !connection._.pingIntervalId && config.pingInterval) {
                 connection._.pingIntervalId = window.setInterval(function () {
-                    _signalR.transports._logic.pingServer(connection).fail(onFail);
+                    signalR.transports._logic.pingServer(connection).fail(onFail);
                 }, config.pingInterval);
             }
         }
     };
 
-    _signalR.events = events;
+    signalR.events = events;
 
-    _signalR.resources = resources;
+    signalR.resources = resources;
 
-    _signalR.ajaxDefaults = ajaxDefaults;
+    signalR.ajaxDefaults = ajaxDefaults;
 
-    _signalR.changeState = changeState;
+    signalR.changeState = changeState;
 
-    _signalR.isDisconnecting = isDisconnecting;
+    signalR.isDisconnecting = isDisconnecting;
 
-    _signalR.connectionState = {
+    signalR.connectionState = {
         connecting: 0,
         connected: 1,
         reconnecting: 2,
         disconnected: 4
     };
 
-    _signalR.hub = {
-        start: function start() {
+    signalR.hub = {
+        start: function () {
             // This will get replaced with the real hub connection start method when hubs is referenced correctly
             throw new Error("SignalR: Error loading hubs. Ensure your hubs reference is correct, e.g. <script src='/signalr/js'></script>.");
         }
@@ -256,13 +255,10 @@ var jQueryShim = require('./jQueryShim');
     // .on() was added in version 1.7.0, .load() was removed in version 3.0.0 so we fallback to .load() if .on() does
     // not exist to not break existing applications
     if (typeof _pageWindow.on == "function") {
-        _pageWindow.on("load", function () {
-            _pageLoaded = true;
-        });
-    } else {
-        _pageWindow.load(function () {
-            _pageLoaded = true;
-        });
+        _pageWindow.on("load", function () { _pageLoaded = true; });
+    }
+    else {
+        _pageWindow.load(function () { _pageLoaded = true; });
     }
 
     function validateTransport(requestedTransport, connection) {
@@ -275,7 +271,7 @@ var jQueryShim = require('./jQueryShim');
             // Go through transport array and remove an "invalid" tranports
             for (var i = requestedTransport.length - 1; i >= 0; i--) {
                 var transport = requestedTransport[i];
-                if ($.type(transport) !== "string" || !_signalR.transports[transport]) {
+                if ($.type(transport) !== "string" || !signalR.transports[transport]) {
                     connection.log("Invalid transport: " + transport + ", removing it from the transports list.");
                     requestedTransport.splice(i, 1);
                 }
@@ -286,12 +282,13 @@ var jQueryShim = require('./jQueryShim');
                 connection.log("No transports remain within the specified transport array.");
                 requestedTransport = null;
             }
-        } else if (!_signalR.transports[requestedTransport] && requestedTransport !== "auto") {
+        } else if (!signalR.transports[requestedTransport] && requestedTransport !== "auto") {
             connection.log("Invalid transport: " + requestedTransport.toString() + ".");
             requestedTransport = null;
-        } else if (requestedTransport === "auto" && _signalR._.ieVersion <= 8) {
+        } else if (requestedTransport === "auto" && signalR._.ieVersion <= 8) {
             // If we're doing an auto transport and we're IE8 then force longPolling, #1764
             return ["longPolling"];
+
         }
 
         return requestedTransport;
@@ -343,8 +340,8 @@ var jQueryShim = require('./jQueryShim');
         };
     }
 
-    _signalR.fn = _signalR.prototype = {
-        init: function init(url, qs, logging) {
+    signalR.fn = signalR.prototype = {
+        init: function (url, qs, logging) {
             var $connection = $(this);
 
             this.url = url;
@@ -361,12 +358,12 @@ var jQueryShim = require('./jQueryShim');
                 beatHandle: null,
                 totalTransportConnectTimeout: 0 // This will be the sum of the TransportConnectTimeout sent in response to negotiate and connection.transportConnectTimeout
             };
-            if (typeof logging === "boolean") {
+            if (typeof (logging) === "boolean") {
                 this.logging = logging;
             }
         },
 
-        _parseResponse: function _parseResponse(response) {
+        _parseResponse: function (response) {
             var that = this;
 
             if (!response) {
@@ -382,7 +379,7 @@ var jQueryShim = require('./jQueryShim');
 
         json: window.JSON,
 
-        isCrossDomain: function isCrossDomain(url, against) {
+        isCrossDomain: function (url, against) {
             /// <summary>Checks if url is cross domain</summary>
             /// <param name="url" type="String">The base URL</param>
             /// <param name="against" type="Object">
@@ -413,7 +410,7 @@ var jQueryShim = require('./jQueryShim');
 
         logging: false,
 
-        state: _signalR.connectionState.disconnected,
+        state: signalR.connectionState.disconnected,
 
         clientProtocol: "1.5",
 
@@ -427,21 +424,20 @@ var jQueryShim = require('./jQueryShim');
 
         keepAliveWarnAt: 2 / 3, // Warn user of slow connection if we breach the X% mark of the keep alive timeout
 
-        start: function start(options, callback) {
+        start: function (options, callback) {
             /// <summary>Starts the connection</summary>
             /// <param name="options" type="Object">Options map</param>
             /// <param name="callback" type="Function">A callback function to execute when the connection has started</param>
             var connection = this,
                 config = {
-                pingInterval: 300000,
-                waitForPageLoad: true,
-                transport: "auto",
-                jsonp: false
-            },
-                _initialize,
-                deferred = connection._deferral || $.Deferred(),
-                // Check to see if there is a pre-existing deferral that's being built on, if so we want to keep using it
-            parser = window.document.createElement("a");
+                    pingInterval: 300000,
+                    waitForPageLoad: true,
+                    transport: "auto",
+                    jsonp: false
+                },
+                initialize,
+                deferred = connection._deferral || $.Deferred(), // Check to see if there is a pre-existing deferral that's being built on, if so we want to keep using it
+                parser = window.document.createElement("a");
 
             connection.lastError = null;
 
@@ -484,9 +480,11 @@ var jQueryShim = require('./jQueryShim');
             }
 
             // If we're already connecting just return the same deferral as the original connection start
-            if (connection.state === _signalR.connectionState.connecting) {
+            if (connection.state === signalR.connectionState.connecting) {
                 return deferred.promise();
-            } else if (changeState(connection, _signalR.connectionState.disconnected, _signalR.connectionState.connecting) === false) {
+            } else if (changeState(connection,
+                            signalR.connectionState.disconnected,
+                            signalR.connectionState.connecting) === false) {
                 // We're not connecting so try and transition into connecting.
                 // If we fail to transition then we're either in connected or reconnecting.
 
@@ -533,7 +531,7 @@ var jQueryShim = require('./jQueryShim');
                     config.transport = ["webSockets", "serverSentEvents", "longPolling"];
                 }
 
-                if (typeof config.withCredentials === "undefined") {
+                if (typeof (config.withCredentials) === "undefined") {
                     config.withCredentials = true;
                 }
 
@@ -548,7 +546,7 @@ var jQueryShim = require('./jQueryShim');
                     }
                 }
 
-                connection.contentType = _signalR._.defaultContentType;
+                connection.contentType = signalR._.defaultContentType;
             }
 
             connection.withCredentials = config.withCredentials;
@@ -562,10 +560,10 @@ var jQueryShim = require('./jQueryShim');
                 deferred.resolve(connection);
             });
 
-            connection._.initHandler = _signalR.transports._logic.initHandler(connection);
+            connection._.initHandler = signalR.transports._logic.initHandler(connection);
 
-            _initialize = function initialize(transports, index) {
-                var noTransportError = _signalR._.error(resources.noTransportOnInit);
+            initialize = function (transports, index) {
+                var noTransportError = signalR._.error(resources.noTransportOnInit);
 
                 index = index || 0;
                 if (index >= transports.length) {
@@ -586,38 +584,39 @@ var jQueryShim = require('./jQueryShim');
                 }
 
                 // The connection was aborted
-                if (connection.state === _signalR.connectionState.disconnected) {
+                if (connection.state === signalR.connectionState.disconnected) {
                     return;
                 }
 
                 var transportName = transports[index],
-                    transport = _signalR.transports[transportName],
-                    onFallback = function onFallback() {
-                    _initialize(transports, index + 1);
-                };
+                    transport = signalR.transports[transportName],
+                    onFallback = function () {
+                        initialize(transports, index + 1);
+                    };
 
                 connection.transport = transport;
 
                 try {
-                    connection._.initHandler.start(transport, function () {
-                        // success
+                    connection._.initHandler.start(transport, function () { // success
                         // Firefox 11+ doesn't allow sync XHR withCredentials: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#withCredentials
-                        var isFirefox11OrGreater = _signalR._.firefoxMajorVersion(window.navigator.userAgent) >= 11,
+                        var isFirefox11OrGreater = signalR._.firefoxMajorVersion(window.navigator.userAgent) >= 11,
                             asyncAbort = !!connection.withCredentials && isFirefox11OrGreater;
 
                         connection.log("The start request succeeded. Transitioning to the connected state.");
 
                         if (supportsKeepAlive(connection)) {
-                            _signalR.transports._logic.monitorKeepAlive(connection);
+                            signalR.transports._logic.monitorKeepAlive(connection);
                         }
 
-                        _signalR.transports._logic.startHeartbeat(connection);
+                        signalR.transports._logic.startHeartbeat(connection);
 
                         // Used to ensure low activity clients maintain their authentication.
                         // Must be configured once a transport has been decided to perform valid ping requests.
-                        _signalR._.configurePingInterval(connection);
+                        signalR._.configurePingInterval(connection);
 
-                        if (!changeState(connection, _signalR.connectionState.connecting, _signalR.connectionState.connected)) {
+                        if (!changeState(connection,
+                                            signalR.connectionState.connecting,
+                                            signalR.connectionState.connected)) {
                             connection.log("WARNING! The connection was not in the connecting state.");
                         }
 
@@ -645,41 +644,42 @@ var jQueryShim = require('./jQueryShim');
                             });
                         }
                     }, onFallback);
-                } catch (error) {
+                }
+                catch (error) {
                     connection.log(transport.name + " transport threw '" + error.message + "' when attempting to start.");
                     onFallback();
                 }
             };
 
             var url = connection.url + "/negotiate",
-                onFailed = function onFailed(error, connection) {
-                var err = _signalR._.error(resources.errorOnNegotiate, error, connection._.negotiateRequest);
+                onFailed = function (error, connection) {
+                    var err = signalR._.error(resources.errorOnNegotiate, error, connection._.negotiateRequest);
 
-                $(connection).triggerHandler(events.onError, err);
-                deferred.reject(err);
-                // Stop the connection if negotiate failed
-                connection.stop();
-            };
+                    $(connection).triggerHandler(events.onError, err);
+                    deferred.reject(err);
+                    // Stop the connection if negotiate failed
+                    connection.stop();
+                };
 
             $(connection).triggerHandler(events.onStarting);
 
-            url = _signalR.transports._logic.prepareQueryString(connection, url);
+            url = signalR.transports._logic.prepareQueryString(connection, url);
 
             connection.log("Negotiating with '" + url + "'.");
 
             // Save the ajax negotiate request object so we can abort it if stop is called while the request is in flight.
-            connection._.negotiateRequest = _signalR.transports._logic.ajax(connection, {
+            connection._.negotiateRequest = signalR.transports._logic.ajax(connection, {
                 url: url,
-                error: function error(_error, statusText) {
+                error: function (error, statusText) {
                     // We don't want to cause any errors if we're aborting our own negotiate request.
                     if (statusText !== _negotiateAbortText) {
-                        onFailed(_error, connection);
+                        onFailed(error, connection);
                     } else {
                         // This rejection will noop if the deferred has already been resolved or rejected.
-                        deferred.reject(_signalR._.error(resources.stoppedWhileNegotiating, null /* error */, connection._.negotiateRequest));
+                        deferred.reject(signalR._.error(resources.stoppedWhileNegotiating, null /* error */, connection._.negotiateRequest));
                     }
                 },
-                success: function success(result) {
+                success: function (result) {
                     var res,
                         keepAliveData,
                         protocolError,
@@ -689,7 +689,7 @@ var jQueryShim = require('./jQueryShim');
                     try {
                         res = connection._parseResponse(result);
                     } catch (error) {
-                        onFailed(_signalR._.error(resources.errorParsingNegotiateResponse, error), connection);
+                        onFailed(signalR._.error(resources.errorParsingNegotiateResponse, error), connection);
                         return;
                     }
 
@@ -729,15 +729,15 @@ var jQueryShim = require('./jQueryShim');
                     connection.reconnectWindow = connection.disconnectTimeout + (keepAliveData.timeout || 0);
 
                     if (!res.ProtocolVersion || res.ProtocolVersion !== connection.clientProtocol) {
-                        protocolError = _signalR._.error(_signalR._.format(resources.protocolIncompatible, connection.clientProtocol, res.ProtocolVersion));
+                        protocolError = signalR._.error(signalR._.format(resources.protocolIncompatible, connection.clientProtocol, res.ProtocolVersion));
                         $(connection).triggerHandler(events.onError, [protocolError]);
                         deferred.reject(protocolError);
 
                         return;
                     }
 
-                    $.each(_signalR.transports, function (key) {
-                        if (key.indexOf("_") === 0 || key === "webSockets" && !res.TryWebSockets) {
+                    $.each(signalR.transports, function (key) {
+                        if ((key.indexOf("_") === 0) || (key === "webSockets" && !res.TryWebSockets)) {
                             return true;
                         }
                         supportedTransports.push(key);
@@ -755,14 +755,14 @@ var jQueryShim = require('./jQueryShim');
                         transports.push(config.transport);
                     }
 
-                    _initialize(transports);
+                    initialize(transports);
                 }
             });
 
             return deferred.promise();
         },
 
-        starting: function starting(callback) {
+        starting: function (callback) {
             /// <summary>Adds a callback that will be invoked before anything is sent over the connection</summary>
             /// <param name="callback" type="Function">A callback function to execute before the connection is fully instantiated.</param>
             /// <returns type="signalR" />
@@ -773,18 +773,18 @@ var jQueryShim = require('./jQueryShim');
             return connection;
         },
 
-        send: function send(data) {
+        send: function (data) {
             /// <summary>Sends data over the connection</summary>
             /// <param name="data" type="String">The data to send over the connection</param>
             /// <returns type="signalR" />
             var connection = this;
 
-            if (connection.state === _signalR.connectionState.disconnected) {
+            if (connection.state === signalR.connectionState.disconnected) {
                 // Connection hasn't been started yet
                 throw new Error("SignalR: Connection must be started before data can be sent. Call .start() before .send()");
             }
 
-            if (connection.state === _signalR.connectionState.connecting) {
+            if (connection.state === signalR.connectionState.connecting) {
                 // Connection hasn't been started yet
                 throw new Error("SignalR: Connection has not been fully initialized. Use .start().done() or .start().fail() to run logic after the connection has started.");
             }
@@ -794,7 +794,7 @@ var jQueryShim = require('./jQueryShim');
             return connection;
         },
 
-        received: function received(callback) {
+        received: function (callback) {
             /// <summary>Adds a callback that will be invoked after anything is received over the connection</summary>
             /// <param name="callback" type="Function">A callback function to execute when any data is received on the connection</param>
             /// <returns type="signalR" />
@@ -805,7 +805,7 @@ var jQueryShim = require('./jQueryShim');
             return connection;
         },
 
-        stateChanged: function stateChanged(callback) {
+        stateChanged: function (callback) {
             /// <summary>Adds a callback that will be invoked when the connection state changes</summary>
             /// <param name="callback" type="Function">A callback function to execute when the connection state changes</param>
             /// <returns type="signalR" />
@@ -816,7 +816,7 @@ var jQueryShim = require('./jQueryShim');
             return connection;
         },
 
-        error: function error(callback) {
+        error: function (callback) {
             /// <summary>Adds a callback that will be invoked after an error occurs with the connection</summary>
             /// <param name="callback" type="Function">A callback function to execute when an error occurs on the connection</param>
             /// <returns type="signalR" />
@@ -831,7 +831,7 @@ var jQueryShim = require('./jQueryShim');
             return connection;
         },
 
-        disconnected: function disconnected(callback) {
+        disconnected: function (callback) {
             /// <summary>Adds a callback that will be invoked when the client disconnects</summary>
             /// <param name="callback" type="Function">A callback function to execute when the connection is broken</param>
             /// <returns type="signalR" />
@@ -842,7 +842,7 @@ var jQueryShim = require('./jQueryShim');
             return connection;
         },
 
-        connectionSlow: function connectionSlow(callback) {
+        connectionSlow: function (callback) {
             /// <summary>Adds a callback that will be invoked when the client detects a slow connection</summary>
             /// <param name="callback" type="Function">A callback function to execute when the connection is slow</param>
             /// <returns type="signalR" />
@@ -854,7 +854,7 @@ var jQueryShim = require('./jQueryShim');
             return connection;
         },
 
-        reconnecting: function reconnecting(callback) {
+        reconnecting: function (callback) {
             /// <summary>Adds a callback that will be invoked when the underlying transport begins reconnecting</summary>
             /// <param name="callback" type="Function">A callback function to execute when the connection enters a reconnecting state</param>
             /// <returns type="signalR" />
@@ -865,7 +865,7 @@ var jQueryShim = require('./jQueryShim');
             return connection;
         },
 
-        reconnected: function reconnected(callback) {
+        reconnected: function (callback) {
             /// <summary>Adds a callback that will be invoked when the underlying transport reconnects</summary>
             /// <param name="callback" type="Function">A callback function to execute when the connection is restored</param>
             /// <returns type="signalR" />
@@ -876,15 +876,14 @@ var jQueryShim = require('./jQueryShim');
             return connection;
         },
 
-        stop: function stop(async, notifyServer) {
+        stop: function (async, notifyServer) {
             /// <summary>Stops listening</summary>
             /// <param name="async" type="Boolean">Whether or not to asynchronously abort the connection</param>
             /// <param name="notifyServer" type="Boolean">Whether we want to notify the server that we are aborting the connection</param>
             /// <returns type="signalR" />
             var connection = this,
-
-            // Save deferral because this is always cleaned up
-            deferral = connection._deferral;
+                // Save deferral because this is always cleaned up
+                deferral = connection._deferral;
 
             // Verify that we've bound a load event.
             if (connection._.deferredStartHandler) {
@@ -903,14 +902,14 @@ var jQueryShim = require('./jQueryShim');
 
                 // If we have a deferral we should reject it
                 if (deferral) {
-                    deferral.reject(_signalR._.error(resources.stoppedWhileLoading));
+                    deferral.reject(signalR._.error(resources.stoppedWhileLoading));
                 }
 
                 // Short-circuit because the start has not been fully started.
                 return;
             }
 
-            if (connection.state === _signalR.connectionState.disconnected) {
+            if (connection.state === signalR.connectionState.disconnected) {
                 return;
             }
 
@@ -928,7 +927,7 @@ var jQueryShim = require('./jQueryShim');
                 }
 
                 if (supportsKeepAlive(connection)) {
-                    _signalR.transports._logic.stopMonitoringKeepAlive(connection);
+                    signalR.transports._logic.stopMonitoringKeepAlive(connection);
                 }
 
                 connection.transport = null;
@@ -957,34 +956,35 @@ var jQueryShim = require('./jQueryShim');
             connection._.connectingMessageBuffer.clear();
 
             // Trigger the disconnect event
-            changeState(connection, connection.state, _signalR.connectionState.disconnected);
+            changeState(connection, connection.state, signalR.connectionState.disconnected);
             $(connection).triggerHandler(events.onDisconnect);
 
             return connection;
         },
 
-        log: function log(msg) {
-            _log(msg, this.logging);
+        log: function (msg) {
+            log(msg, this.logging);
         }
     };
 
-    _signalR.fn.init.prototype = _signalR.fn;
+    signalR.fn.init.prototype = signalR.fn;
 
-    _signalR.noConflict = function () {
+    signalR.noConflict = function () {
         /// <summary>Reinstates the original value of $.connection and returns the signalR object for manual assignment</summary>
         /// <returns type="signalR" />
-        if ($.connection === _signalR) {
+        if ($.connection === signalR) {
             $.connection = _connection;
         }
-        return _signalR;
+        return signalR;
     };
 
     if ($.connection) {
         _connection = $.connection;
     }
 
-    $.connection = $.signalR = _signalR;
-})(jQueryShim, window);
+    $.connection = $.signalR = signalR;
+
+}(jQueryShim, window));
 /* jquery.signalR.transports.common.js */
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
@@ -1061,7 +1061,7 @@ var jQueryShim = require('./jQueryShim');
     }
 
     InitHandler.prototype = {
-        start: function start(transport, onSuccess, onFallback) {
+        start: function (transport, onSuccess, onFallback) {
             var that = this,
                 connection = that.connection,
                 failCalled = false;
@@ -1098,13 +1098,13 @@ var jQueryShim = require('./jQueryShim');
             }, connection._.totalTransportConnectTimeout);
         },
 
-        stop: function stop() {
+        stop: function () {
             this.connectionStopped = true;
             window.clearTimeout(this.transportTimeoutHandle);
             signalR.transports._logic.tryAbortStartRequest(this.connection);
         },
 
-        initReceived: function initReceived(transport, onSuccess) {
+        initReceived: function (transport, onSuccess) {
             var that = this,
                 connection = that.connection;
 
@@ -1127,7 +1127,7 @@ var jQueryShim = require('./jQueryShim');
             });
         },
 
-        transportFailed: function transportFailed(transport, error, onFallback) {
+        transportFailed: function (transport, error, onFallback) {
             var connection = this.connection,
                 deferred = connection._deferral,
                 wrappedError;
@@ -1163,17 +1163,18 @@ var jQueryShim = require('./jQueryShim');
     };
 
     transportLogic = signalR.transports._logic = {
-        ajax: function ajax(connection, options) {
-            return $.ajax($.extend( /*deep copy*/true, {}, $.signalR.ajaxDefaults, {
-                type: "GET",
-                data: {},
-                xhrFields: { withCredentials: connection.withCredentials },
-                contentType: connection.contentType,
-                dataType: connection.ajaxDataType
-            }, options));
+        ajax: function (connection, options) {
+            return $.ajax(
+                $.extend(/*deep copy*/ true, {}, $.signalR.ajaxDefaults, {
+                    type: "GET",
+                    data: {},
+                    xhrFields: { withCredentials: connection.withCredentials },
+                    contentType: connection.contentType,
+                    dataType: connection.ajaxDataType
+                }, options));
         },
 
-        pingServer: function pingServer(connection) {
+        pingServer: function (connection) {
             /// <summary>Pings the server</summary>
             /// <param name="connection" type="signalr">Connection associated with the server ping</param>
             /// <returns type="signalR" />
@@ -1188,41 +1189,77 @@ var jQueryShim = require('./jQueryShim');
 
                 xhr = transportLogic.ajax(connection, {
                     url: url,
-                    success: function success(result) {
+                    success: function (result) {
                         var data;
 
                         try {
                             data = connection._parseResponse(result);
-                        } catch (error) {
-                            deferral.reject(signalR._.transportError(signalR.resources.pingServerFailedParse, connection.transport, error, xhr));
+                        }
+                        catch (error) {
+                            deferral.reject(
+                                signalR._.transportError(
+                                    signalR.resources.pingServerFailedParse,
+                                    connection.transport,
+                                    error,
+                                    xhr
+                                )
+                            );
                             connection.stop();
                             return;
                         }
 
                         if (data.Response === "pong") {
                             deferral.resolve();
-                        } else {
-                            deferral.reject(signalR._.transportError(signalR._.format(signalR.resources.pingServerFailedInvalidResponse, result), connection.transport, null /* error */
-                            , xhr));
+                        }
+                        else {
+                            deferral.reject(
+                                signalR._.transportError(
+                                    signalR._.format(signalR.resources.pingServerFailedInvalidResponse, result),
+                                    connection.transport,
+                                    null /* error */,
+                                    xhr
+                                )
+                            );
                         }
                     },
-                    error: function error(_error2) {
-                        if (_error2.status === 401 || _error2.status === 403) {
-                            deferral.reject(signalR._.transportError(signalR._.format(signalR.resources.pingServerFailedStatusCode, _error2.status), connection.transport, _error2, xhr));
+                    error: function (error) {
+                        if (error.status === 401 || error.status === 403) {
+                            deferral.reject(
+                                signalR._.transportError(
+                                    signalR._.format(signalR.resources.pingServerFailedStatusCode, error.status),
+                                    connection.transport,
+                                    error,
+                                    xhr
+                                )
+                            );
                             connection.stop();
-                        } else {
-                            deferral.reject(signalR._.transportError(signalR.resources.pingServerFailed, connection.transport, _error2, xhr));
+                        }
+                        else {
+                            deferral.reject(
+                                signalR._.transportError(
+                                    signalR.resources.pingServerFailed,
+                                    connection.transport,
+                                    error,
+                                    xhr
+                                )
+                            );
                         }
                     }
                 });
-            } else {
-                deferral.reject(signalR._.transportError(signalR.resources.noConnectionTransport, connection.transport));
+            }
+            else {
+                deferral.reject(
+                    signalR._.transportError(
+                        signalR.resources.noConnectionTransport,
+                        connection.transport
+                    )
+                );
             }
 
             return deferral.promise();
         },
 
-        prepareQueryString: function prepareQueryString(connection, url) {
+        prepareQueryString: function (connection, url) {
             var preparedUrl;
 
             // Use addQs to start since it handles the ?/& prefix for us
@@ -1242,7 +1279,7 @@ var jQueryShim = require('./jQueryShim');
             return preparedUrl;
         },
 
-        addQs: function addQs(url, qs) {
+        addQs: function (url, qs) {
             var appender = url.indexOf("?") !== -1 ? "&" : "?",
                 firstChar;
 
@@ -1250,11 +1287,11 @@ var jQueryShim = require('./jQueryShim');
                 return url;
             }
 
-            if ((typeof qs === 'undefined' ? 'undefined' : _typeof(qs)) === "object") {
+            if (typeof (qs) === "object") {
                 return url + appender + $.param(qs);
             }
 
-            if (typeof qs === "string") {
+            if (typeof (qs) === "string") {
                 firstChar = qs.charAt(0);
 
                 if (firstChar === "?" || firstChar === "&") {
@@ -1268,10 +1305,10 @@ var jQueryShim = require('./jQueryShim');
         },
 
         // BUG #2953: The url needs to be same otherwise it will cause a memory leak
-        getUrl: function getUrl(connection, transport, reconnecting, poll, ajaxPost) {
+        getUrl: function (connection, transport, reconnecting, poll, ajaxPost) {
             /// <summary>Gets the url for making a GET based connect request</summary>
             var baseUrl = transport === "webSockets" ? "" : connection.baseUrl,
-                url = baseUrl + connection.url,
+                url = baseUrl + connection.appRelativeUrl,
                 qs = "transport=" + transport;
 
             if (!ajaxPost && connection.groupsToken) {
@@ -1302,37 +1339,38 @@ var jQueryShim = require('./jQueryShim');
             return url;
         },
 
-        maximizePersistentResponse: function maximizePersistentResponse(minPersistentResponse) {
+        maximizePersistentResponse: function (minPersistentResponse) {
             return {
                 MessageId: minPersistentResponse.C,
                 Messages: minPersistentResponse.M,
-                Initialized: typeof minPersistentResponse.S !== "undefined" ? true : false,
-                ShouldReconnect: typeof minPersistentResponse.T !== "undefined" ? true : false,
+                Initialized: typeof (minPersistentResponse.S) !== "undefined" ? true : false,
+                ShouldReconnect: typeof (minPersistentResponse.T) !== "undefined" ? true : false,
                 LongPollDelay: minPersistentResponse.L,
                 GroupsToken: minPersistentResponse.G
             };
         },
 
-        updateGroups: function updateGroups(connection, groupsToken) {
+        updateGroups: function (connection, groupsToken) {
             if (groupsToken) {
                 connection.groupsToken = groupsToken;
             }
         },
 
-        stringifySend: function stringifySend(connection, message) {
-            if (typeof message === "string" || typeof message === "undefined" || message === null) {
+        stringifySend: function (connection, message) {
+            if (typeof (message) === "string" || typeof (message) === "undefined" || message === null) {
                 return message;
             }
             return connection.json.stringify(message);
         },
 
-        ajaxSend: function ajaxSend(connection, data) {
+        ajaxSend: function (connection, data) {
             var payload = transportLogic.stringifySend(connection, data),
                 url = getAjaxUrl(connection, "/send"),
                 xhr,
-                onFail = function onFail(error, connection) {
-                $(connection).triggerHandler(events.onError, [signalR._.transportError(signalR.resources.sendFailed, connection.transport, error, xhr), data]);
-            };
+                onFail = function (error, connection) {
+                    $(connection).triggerHandler(events.onError, [signalR._.transportError(signalR.resources.sendFailed, connection.transport, error, xhr), data]);
+                };
+
 
             xhr = transportLogic.ajax(connection, {
                 url: url,
@@ -1341,13 +1379,14 @@ var jQueryShim = require('./jQueryShim');
                 data: {
                     data: payload
                 },
-                success: function success(result) {
+                success: function (result) {
                     var res;
 
                     if (result) {
                         try {
                             res = connection._parseResponse(result);
-                        } catch (error) {
+                        }
+                        catch (error) {
                             onFail(error, connection);
                             connection.stop();
                             return;
@@ -1356,7 +1395,7 @@ var jQueryShim = require('./jQueryShim');
                         transportLogic.triggerReceived(connection, res);
                     }
                 },
-                error: function error(_error3, textStatus) {
+                error: function (error, textStatus) {
                     if (textStatus === "abort" || textStatus === "parsererror") {
                         // The parsererror happens for sends that don't return any data, and hence
                         // don't write the jsonp callback to the response. This is harder to fix on the server
@@ -1364,15 +1403,15 @@ var jQueryShim = require('./jQueryShim');
                         return;
                     }
 
-                    onFail(_error3, connection);
+                    onFail(error, connection);
                 }
             });
 
             return xhr;
         },
 
-        ajaxAbort: function ajaxAbort(connection, async) {
-            if (typeof connection.transport === "undefined") {
+        ajaxAbort: function (connection, async) {
+            if (typeof (connection.transport) === "undefined") {
                 return;
             }
 
@@ -1391,52 +1430,60 @@ var jQueryShim = require('./jQueryShim');
             connection.log("Fired ajax abort async = " + async + ".");
         },
 
-        ajaxStart: function ajaxStart(connection, onSuccess) {
-            var rejectDeferred = function rejectDeferred(error) {
-                var deferred = connection._deferral;
-                if (deferred) {
-                    deferred.reject(error);
-                }
-            },
-                triggerStartError = function triggerStartError(error) {
-                connection.log("The start request failed. Stopping the connection.");
-                $(connection).triggerHandler(events.onError, [error]);
-                rejectDeferred(error);
-                connection.stop();
-            };
+        ajaxStart: function (connection, onSuccess) {
+            var rejectDeferred = function (error) {
+                    var deferred = connection._deferral;
+                    if (deferred) {
+                        deferred.reject(error);
+                    }
+                },
+                triggerStartError = function (error) {
+                    connection.log("The start request failed. Stopping the connection.");
+                    $(connection).triggerHandler(events.onError, [error]);
+                    rejectDeferred(error);
+                    connection.stop();
+                };
 
             connection._.startRequest = transportLogic.ajax(connection, {
                 url: getAjaxUrl(connection, "/start"),
-                success: function success(result, statusText, xhr) {
+                success: function (result, statusText, xhr) {
                     var data;
 
                     try {
                         data = connection._parseResponse(result);
                     } catch (error) {
-                        triggerStartError(signalR._.error(signalR._.format(signalR.resources.errorParsingStartResponse, result), error, xhr));
+                        triggerStartError(signalR._.error(
+                            signalR._.format(signalR.resources.errorParsingStartResponse, result),
+                            error, xhr));
                         return;
                     }
 
                     if (data.Response === "started") {
                         onSuccess();
                     } else {
-                        triggerStartError(signalR._.error(signalR._.format(signalR.resources.invalidStartResponse, result), null /* error */, xhr));
+                        triggerStartError(signalR._.error(
+                            signalR._.format(signalR.resources.invalidStartResponse, result),
+                            null /* error */, xhr));
                     }
                 },
-                error: function error(xhr, statusText, _error4) {
+                error: function (xhr, statusText, error) {
                     if (statusText !== startAbortText) {
-                        triggerStartError(signalR._.error(signalR.resources.errorDuringStartRequest, _error4, xhr));
+                        triggerStartError(signalR._.error(
+                            signalR.resources.errorDuringStartRequest,
+                            error, xhr));
                     } else {
                         // Stop has been called, no need to trigger the error handler
                         // or stop the connection again with onStartError
                         connection.log("The start request aborted because connection.stop() was called.");
-                        rejectDeferred(signalR._.error(signalR.resources.stoppedDuringStartRequest, null /* error */, xhr));
+                        rejectDeferred(signalR._.error(
+                            signalR.resources.stoppedDuringStartRequest,
+                            null /* error */, xhr));
                     }
                 }
             });
         },
 
-        tryAbortStartRequest: function tryAbortStartRequest(connection) {
+        tryAbortStartRequest: function (connection) {
             if (connection._.startRequest) {
                 // If the start request has already completed this will noop.
                 connection._.startRequest.abort(startAbortText);
@@ -1444,21 +1491,22 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        tryInitialize: function tryInitialize(connection, persistentResponse, onInitialized) {
+        tryInitialize: function (connection, persistentResponse, onInitialized) {
             if (persistentResponse.Initialized && onInitialized) {
                 onInitialized();
             } else if (persistentResponse.Initialized) {
                 connection.log("WARNING! The client received an init message after reconnecting.");
             }
+
         },
 
-        triggerReceived: function triggerReceived(connection, data) {
+        triggerReceived: function (connection, data) {
             if (!connection._.connectingMessageBuffer.tryBuffer(data)) {
                 $(connection).triggerHandler(events.onReceived, [data]);
             }
         },
 
-        processMessages: function processMessages(connection, minData, onInitialized) {
+        processMessages: function (connection, minData, onInitialized) {
             var data;
 
             // Update the last message time stamp
@@ -1483,7 +1531,7 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        monitorKeepAlive: function monitorKeepAlive(connection) {
+        monitorKeepAlive: function (connection) {
             var keepAliveData = connection._.keepAliveData;
 
             // If we haven't initiated the keep alive timeouts then we need to
@@ -1507,7 +1555,7 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        stopMonitoringKeepAlive: function stopMonitoringKeepAlive(connection) {
+        stopMonitoringKeepAlive: function (connection) {
             var keepAliveData = connection._.keepAliveData;
 
             // Only attempt to stop the keep alive monitoring if its being monitored
@@ -1524,16 +1572,16 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        startHeartbeat: function startHeartbeat(connection) {
+        startHeartbeat: function (connection) {
             connection._.lastActiveAt = new Date().getTime();
             beat(connection);
         },
 
-        markLastMessage: function markLastMessage(connection) {
+        markLastMessage: function (connection) {
             connection._.lastMessageAt = new Date().getTime();
         },
 
-        markActive: function markActive(connection) {
+        markActive: function (connection) {
             if (transportLogic.verifyLastActive(connection)) {
                 connection._.lastActiveAt = new Date().getTime();
                 return true;
@@ -1542,37 +1590,40 @@ var jQueryShim = require('./jQueryShim');
             return false;
         },
 
-        isConnectedOrReconnecting: function isConnectedOrReconnecting(connection) {
-            return connection.state === signalR.connectionState.connected || connection.state === signalR.connectionState.reconnecting;
+        isConnectedOrReconnecting: function (connection) {
+            return connection.state === signalR.connectionState.connected ||
+                   connection.state === signalR.connectionState.reconnecting;
         },
 
-        ensureReconnectingState: function ensureReconnectingState(connection) {
-            if (changeState(connection, signalR.connectionState.connected, signalR.connectionState.reconnecting) === true) {
+        ensureReconnectingState: function (connection) {
+            if (changeState(connection,
+                        signalR.connectionState.connected,
+                        signalR.connectionState.reconnecting) === true) {
                 $(connection).triggerHandler(events.onReconnecting);
             }
             return connection.state === signalR.connectionState.reconnecting;
         },
 
-        clearReconnectTimeout: function clearReconnectTimeout(connection) {
+        clearReconnectTimeout: function (connection) {
             if (connection && connection._.reconnectTimeout) {
                 window.clearTimeout(connection._.reconnectTimeout);
                 delete connection._.reconnectTimeout;
             }
         },
 
-        verifyLastActive: function verifyLastActive(connection) {
+        verifyLastActive: function (connection) {
             if (new Date().getTime() - connection._.lastActiveAt >= connection.reconnectWindow) {
                 var message = signalR._.format(signalR.resources.reconnectWindowTimeout, new Date(connection._.lastActiveAt), connection.reconnectWindow);
                 connection.log(message);
-                $(connection).triggerHandler(events.onError, [signalR._.error(message, /* source */"TimeoutException")]);
-                connection.stop( /* async */false, /* notifyServer */false);
+                $(connection).triggerHandler(events.onError, [signalR._.error(message, /* source */ "TimeoutException")]);
+                connection.stop(/* async */ false, /* notifyServer */ false);
                 return false;
             }
 
             return true;
         },
 
-        reconnect: function reconnect(connection, transportName) {
+        reconnect: function (connection, transportName) {
             var transport = signalR.transports[transportName];
 
             // We should only set a reconnectTimeout if we are currently connected
@@ -1598,8 +1649,12 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        handleParseFailure: function handleParseFailure(connection, result, error, onFailed, context) {
-            var wrappedError = signalR._.transportError(signalR._.format(signalR.resources.parseFailed, result), connection.transport, error, context);
+        handleParseFailure: function (connection, result, error, onFailed, context) {
+            var wrappedError = signalR._.transportError(
+                signalR._.format(signalR.resources.parseFailed, result),
+                connection.transport,
+                error,
+                context);
 
             // If we're in the initialization phase trigger onFailed, otherwise stop the connection.
             if (onFailed && onFailed(wrappedError)) {
@@ -1610,7 +1665,7 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        initHandler: function initHandler(connection) {
+        initHandler: function (connection) {
             return new InitHandler(connection);
         },
 
@@ -1619,7 +1674,8 @@ var jQueryShim = require('./jQueryShim');
             connections: {}
         }
     };
-})(jQueryShim, window);
+
+}(jQueryShim, window));
 /* jquery.signalR.transports.webSockets.js */
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
@@ -1638,21 +1694,28 @@ var jQueryShim = require('./jQueryShim');
     signalR.transports.webSockets = {
         name: "webSockets",
 
-        supportsKeepAlive: function supportsKeepAlive() {
+        supportsKeepAlive: function () {
             return true;
         },
 
-        send: function send(connection, data) {
+        send: function (connection, data) {
             var payload = transportLogic.stringifySend(connection, data);
 
             try {
                 connection.socket.send(payload);
             } catch (ex) {
-                $(connection).triggerHandler(events.onError, [signalR._.transportError(signalR.resources.webSocketsInvalidState, connection.transport, ex, connection.socket), data]);
+                $(connection).triggerHandler(events.onError,
+                    [signalR._.transportError(
+                        signalR.resources.webSocketsInvalidState,
+                        connection.transport,
+                        ex,
+                        connection.socket
+                    ),
+                    data]);
             }
         },
 
-        start: function start(connection, onSuccess, onFailed) {
+        start: function (connection, onSuccess, onFailed) {
             var url,
                 opened = false,
                 that = this,
@@ -1682,7 +1745,9 @@ var jQueryShim = require('./jQueryShim');
 
                     transportLogic.clearReconnectTimeout(connection);
 
-                    if (changeState(connection, signalR.connectionState.reconnecting, signalR.connectionState.connected) === true) {
+                    if (changeState(connection,
+                                    signalR.connectionState.reconnecting,
+                                    signalR.connectionState.connected) === true) {
                         $connection.triggerHandler(events.onReconnect);
                     }
                 };
@@ -1698,7 +1763,10 @@ var jQueryShim = require('./jQueryShim');
                         if (opened && typeof event.wasClean !== "undefined" && event.wasClean === false) {
                             // Ideally this would use the websocket.onerror handler (rather than checking wasClean in onclose) but
                             // I found in some circumstances Chrome won't call onerror. This implementation seems to work on all browsers.
-                            error = signalR._.transportError(signalR.resources.webSocketClosed, connection.transport, event);
+                            error = signalR._.transportError(
+                                signalR.resources.webSocketClosed,
+                                connection.transport,
+                                event);
 
                             connection.log("Unclean disconnect from websocket: " + (event.reason || "[no reason given]."));
                         } else {
@@ -1720,7 +1788,8 @@ var jQueryShim = require('./jQueryShim');
 
                     try {
                         data = connection._parseResponse(event.data);
-                    } catch (error) {
+                    }
+                    catch (error) {
                         transportLogic.handleParseFailure(connection, event.data, error, onFailed, event);
                         return;
                     }
@@ -1739,15 +1808,15 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        reconnect: function reconnect(connection) {
+        reconnect: function (connection) {
             transportLogic.reconnect(connection, this.name);
         },
 
-        lostConnection: function lostConnection(connection) {
+        lostConnection: function (connection) {
             this.reconnect(connection);
         },
 
-        stop: function stop(connection) {
+        stop: function (connection) {
             // Don't trigger a reconnect after stopping
             transportLogic.clearReconnectTimeout(connection);
 
@@ -1758,11 +1827,12 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        abort: function abort(connection, async) {
+        abort: function (connection, async) {
             transportLogic.ajaxAbort(connection, async);
         }
     };
-})(jQueryShim, window);
+
+}(jQueryShim, window));
 /* jquery.signalR.transports.serverSentEvents.js */
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
@@ -1777,21 +1847,21 @@ var jQueryShim = require('./jQueryShim');
         events = $.signalR.events,
         changeState = $.signalR.changeState,
         transportLogic = signalR.transports._logic,
-        clearReconnectAttemptTimeout = function clearReconnectAttemptTimeout(connection) {
-        window.clearTimeout(connection._.reconnectAttemptTimeoutHandle);
-        delete connection._.reconnectAttemptTimeoutHandle;
-    };
+        clearReconnectAttemptTimeout = function (connection) {
+            window.clearTimeout(connection._.reconnectAttemptTimeoutHandle);
+            delete connection._.reconnectAttemptTimeoutHandle;
+        };
 
     signalR.transports.serverSentEvents = {
         name: "serverSentEvents",
 
-        supportsKeepAlive: function supportsKeepAlive() {
+        supportsKeepAlive: function () {
             return true;
         },
 
         timeOut: 3000,
 
-        start: function start(connection, onSuccess, onFailed) {
+        start: function (connection, onSuccess, onFailed) {
             var that = this,
                 opened = false,
                 $connection = $(connection),
@@ -1816,7 +1886,8 @@ var jQueryShim = require('./jQueryShim');
             try {
                 connection.log("Attempting to connect to SSE endpoint '" + url + "'.");
                 connection.eventSource = new window.EventSource(url, { withCredentials: connection.withCredentials });
-            } catch (e) {
+            }
+            catch (e) {
                 connection.log("EventSource failed trying to connect with error " + e.Message + ".");
                 if (onFailed) {
                     // The connection failed, call the failed callback
@@ -1841,7 +1912,8 @@ var jQueryShim = require('./jQueryShim');
                             that.reconnect(connection);
                         }
                     }
-                }, that.timeOut);
+                },
+                that.timeOut);
             }
 
             connection.eventSource.addEventListener("open", function (e) {
@@ -1853,7 +1925,9 @@ var jQueryShim = require('./jQueryShim');
                 if (opened === false) {
                     opened = true;
 
-                    if (changeState(connection, signalR.connectionState.reconnecting, signalR.connectionState.connected) === true) {
+                    if (changeState(connection,
+                                         signalR.connectionState.reconnecting,
+                                         signalR.connectionState.connected) === true) {
                         $connection.triggerHandler(events.onReconnect);
                     }
                 }
@@ -1869,7 +1943,8 @@ var jQueryShim = require('./jQueryShim');
 
                 try {
                     res = connection._parseResponse(e.data);
-                } catch (error) {
+                }
+                catch (error) {
                     transportLogic.handleParseFailure(connection, e.data, error, onFailed, e);
                     return;
                 }
@@ -1878,7 +1953,10 @@ var jQueryShim = require('./jQueryShim');
             }, false);
 
             connection.eventSource.addEventListener("error", function (e) {
-                var error = signalR._.transportError(signalR.resources.eventSourceError, connection.transport, e);
+                var error = signalR._.transportError(
+                    signalR.resources.eventSourceError,
+                    connection.transport,
+                    e);
 
                 // Only handle an error if the error is from the current Event Source.
                 // Sometimes on disconnect the server will push down an error event
@@ -1908,19 +1986,19 @@ var jQueryShim = require('./jQueryShim');
             }, false);
         },
 
-        reconnect: function reconnect(connection) {
+        reconnect: function (connection) {
             transportLogic.reconnect(connection, this.name);
         },
 
-        lostConnection: function lostConnection(connection) {
+        lostConnection: function (connection) {
             this.reconnect(connection);
         },
 
-        send: function send(connection, data) {
+        send: function (connection, data) {
             transportLogic.ajaxSend(connection, data);
         },
 
-        stop: function stop(connection) {
+        stop: function (connection) {
             // Don't trigger a reconnect after stopping
             clearReconnectAttemptTimeout(connection);
             transportLogic.clearReconnectTimeout(connection);
@@ -1933,11 +2011,12 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        abort: function abort(connection, async) {
+        abort: function (connection, async) {
             transportLogic.ajaxAbort(connection, async);
         }
     };
-})(jQueryShim, window);
+
+}(jQueryShim, window));
 /* jquery.signalR.transports.foreverFrame.js */
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
@@ -1952,74 +2031,73 @@ var jQueryShim = require('./jQueryShim');
         events = $.signalR.events,
         changeState = $.signalR.changeState,
         transportLogic = signalR.transports._logic,
-        createFrame = function createFrame() {
-        var frame = window.document.createElement("iframe");
-        frame.setAttribute("style", "position:absolute;top:0;left:0;width:0;height:0;visibility:hidden;");
-        return frame;
-    },
+        createFrame = function () {
+            var frame = window.document.createElement("iframe");
+            frame.setAttribute("style", "position:absolute;top:0;left:0;width:0;height:0;visibility:hidden;");
+            return frame;
+        },
+        // Used to prevent infinite loading icon spins in older versions of ie
+        // We build this object inside a closure so we don't pollute the rest of
+        // the foreverFrame transport with unnecessary functions/utilities.
+        loadPreventer = (function () {
+            var loadingFixIntervalId = null,
+                loadingFixInterval = 1000,
+                attachedTo = 0;
 
-    // Used to prevent infinite loading icon spins in older versions of ie
-    // We build this object inside a closure so we don't pollute the rest of
-    // the foreverFrame transport with unnecessary functions/utilities.
-    loadPreventer = function () {
-        var loadingFixIntervalId = null,
-            loadingFixInterval = 1000,
-            attachedTo = 0;
+            return {
+                prevent: function () {
+                    // Prevent additional iframe removal procedures from newer browsers
+                    if (signalR._.ieVersion <= 8) {
+                        // We only ever want to set the interval one time, so on the first attachedTo
+                        if (attachedTo === 0) {
+                            // Create and destroy iframe every 3 seconds to prevent loading icon, super hacky
+                            loadingFixIntervalId = window.setInterval(function () {
+                                var tempFrame = createFrame();
 
-        return {
-            prevent: function prevent() {
-                // Prevent additional iframe removal procedures from newer browsers
-                if (signalR._.ieVersion <= 8) {
-                    // We only ever want to set the interval one time, so on the first attachedTo
-                    if (attachedTo === 0) {
-                        // Create and destroy iframe every 3 seconds to prevent loading icon, super hacky
-                        loadingFixIntervalId = window.setInterval(function () {
-                            var tempFrame = createFrame();
+                                window.document.body.appendChild(tempFrame);
+                                window.document.body.removeChild(tempFrame);
 
-                            window.document.body.appendChild(tempFrame);
-                            window.document.body.removeChild(tempFrame);
+                                tempFrame = null;
+                            }, loadingFixInterval);
+                        }
 
-                            tempFrame = null;
-                        }, loadingFixInterval);
+                        attachedTo++;
+                    }
+                },
+                cancel: function () {
+                    // Only clear the interval if there's only one more object that the loadPreventer is attachedTo
+                    if (attachedTo === 1) {
+                        window.clearInterval(loadingFixIntervalId);
                     }
 
-                    attachedTo++;
+                    if (attachedTo > 0) {
+                        attachedTo--;
+                    }
                 }
-            },
-            cancel: function cancel() {
-                // Only clear the interval if there's only one more object that the loadPreventer is attachedTo
-                if (attachedTo === 1) {
-                    window.clearInterval(loadingFixIntervalId);
-                }
-
-                if (attachedTo > 0) {
-                    attachedTo--;
-                }
-            }
-        };
-    }();
+            };
+        })();
 
     signalR.transports.foreverFrame = {
         name: "foreverFrame",
 
-        supportsKeepAlive: function supportsKeepAlive() {
+        supportsKeepAlive: function () {
             return true;
         },
 
         // Added as a value here so we can create tests to verify functionality
         iframeClearThreshold: 50,
 
-        start: function start(connection, onSuccess, onFailed) {
+        start: function (connection, onSuccess, onFailed) {
             var that = this,
-                frameId = transportLogic.foreverFrame.count += 1,
+                frameId = (transportLogic.foreverFrame.count += 1),
                 url,
                 frame = createFrame(),
-                frameLoadHandler = function frameLoadHandler() {
-                connection.log("Forever frame iframe finished loading and is no longer receiving messages.");
-                if (!onFailed || !onFailed()) {
-                    that.reconnect(connection);
-                }
-            };
+                frameLoadHandler = function () {
+                    connection.log("Forever frame iframe finished loading and is no longer receiving messages.");
+                    if (!onFailed || !onFailed()) {
+                        that.reconnect(connection);
+                    }
+                };
 
             if (window.EventSource) {
                 // If the browser supports SSE, don't use Forever Frame
@@ -2065,7 +2143,7 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        reconnect: function reconnect(connection) {
+        reconnect: function (connection) {
             var that = this;
 
             // Need to verify connection state and verify before the setTimeout occurs because an application sleep could occur during the setTimeout duration.
@@ -2086,16 +2164,18 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        lostConnection: function lostConnection(connection) {
+        lostConnection: function (connection) {
             this.reconnect(connection);
         },
 
-        send: function send(connection, data) {
+        send: function (connection, data) {
             transportLogic.ajaxSend(connection, data);
         },
 
-        receive: function receive(connection, data) {
-            var cw, body, response;
+        receive: function (connection, data) {
+            var cw,
+                body,
+                response;
 
             if (connection.json !== connection._originalJson) {
                 // If there's a custom JSON parser configured then serialize the object
@@ -2129,7 +2209,7 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        stop: function stop(connection) {
+        stop: function (connection) {
             var cw = null;
 
             // Stop attempting to prevent loading icon
@@ -2144,7 +2224,8 @@ var jQueryShim = require('./jQueryShim');
                         if (cw.document && cw.document.execCommand) {
                             cw.document.execCommand("Stop");
                         }
-                    } catch (e) {
+                    }
+                    catch (e) {
                         connection.log("Error occurred when stopping foreverFrame transport. Message = " + e.message + ".");
                     }
                 }
@@ -2165,22 +2246,25 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        abort: function abort(connection, async) {
+        abort: function (connection, async) {
             transportLogic.ajaxAbort(connection, async);
         },
 
-        getConnection: function getConnection(id) {
+        getConnection: function (id) {
             return transportLogic.foreverFrame.connections[id];
         },
 
-        started: function started(connection) {
-            if (changeState(connection, signalR.connectionState.reconnecting, signalR.connectionState.connected) === true) {
+        started: function (connection) {
+            if (changeState(connection,
+                signalR.connectionState.reconnecting,
+                signalR.connectionState.connected) === true) {
 
                 $(connection).triggerHandler(events.onReconnect);
             }
         }
     };
-})(jQueryShim, window);
+
+}(jQueryShim, window));
 /* jquery.signalR.transports.longPolling.js */
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
@@ -2200,50 +2284,51 @@ var jQueryShim = require('./jQueryShim');
     signalR.transports.longPolling = {
         name: "longPolling",
 
-        supportsKeepAlive: function supportsKeepAlive() {
+        supportsKeepAlive: function () {
             return false;
         },
 
         reconnectDelay: 3000,
 
-        start: function start(connection, onSuccess, onFailed) {
+        start: function (connection, onSuccess, onFailed) {
             /// <summary>Starts the long polling connection</summary>
             /// <param name="connection" type="signalR">The SignalR connection to start</param>
             var that = this,
-                _fireConnect = function fireConnect() {
-                _fireConnect = $.noop;
+                fireConnect = function () {
+                    fireConnect = $.noop;
 
-                connection.log("LongPolling connected.");
+                    connection.log("LongPolling connected.");
 
-                if (onSuccess) {
-                    onSuccess();
-                } else {
-                    connection.log("WARNING! The client received an init message after reconnecting.");
-                }
-            },
-                tryFailConnect = function tryFailConnect(error) {
-                if (onFailed(error)) {
-                    connection.log("LongPolling failed to connect.");
-                    return true;
-                }
+                    if (onSuccess) {
+                        onSuccess();
+                    } else {
+                        connection.log("WARNING! The client received an init message after reconnecting.");
+                    }
+                },
+                tryFailConnect = function (error) {
+                    if (onFailed(error)) {
+                        connection.log("LongPolling failed to connect.");
+                        return true;
+                    }
 
-                return false;
-            },
+                    return false;
+                },
                 privateData = connection._,
                 reconnectErrors = 0,
-                fireReconnected = function fireReconnected(instance) {
-                window.clearTimeout(privateData.reconnectTimeoutId);
-                privateData.reconnectTimeoutId = null;
+                fireReconnected = function (instance) {
+                    window.clearTimeout(privateData.reconnectTimeoutId);
+                    privateData.reconnectTimeoutId = null;
 
-                if (changeState(instance, signalR.connectionState.reconnecting, signalR.connectionState.connected) === true) {
-                    // Successfully reconnected!
-                    instance.log("Raising the reconnect event");
-                    $(instance).triggerHandler(events.onReconnect);
-                }
-            },
-
-            // 1 hour
-            maxFireReconnectedTimeout = 3600000;
+                    if (changeState(instance,
+                                    signalR.connectionState.reconnecting,
+                                    signalR.connectionState.connected) === true) {
+                        // Successfully reconnected!
+                        instance.log("Raising the reconnect event");
+                        $(instance).triggerHandler(events.onReconnect);
+                    }
+                },
+                // 1 hour
+                maxFireReconnectedTimeout = 3600000;
 
             if (connection.pollXhr) {
                 connection.log("Polling xhr requests already exists, aborting.");
@@ -2257,7 +2342,7 @@ var jQueryShim = require('./jQueryShim');
             privateData.pollTimeoutId = window.setTimeout(function () {
                 (function poll(instance, raiseReconnect) {
                     var messageId = instance.messageId,
-                        connect = messageId === null,
+                        connect = (messageId === null),
                         reconnecting = !connect,
                         polling = !raiseReconnect,
                         url = transportLogic.getUrl(instance, that.name, reconnecting, polling, true /* use Post for longPolling */),
@@ -2279,7 +2364,7 @@ var jQueryShim = require('./jQueryShim');
                     connection.log("Opening long polling request to '" + url + "'.");
                     instance.pollXhr = transportLogic.ajax(connection, {
                         xhrFields: {
-                            onprogress: function onprogress() {
+                            onprogress: function () {
                                 transportLogic.markLastMessage(connection);
                             }
                         },
@@ -2288,7 +2373,7 @@ var jQueryShim = require('./jQueryShim');
                         contentType: signalR._.defaultContentType,
                         data: postData,
                         timeout: connection._.pollTimeout,
-                        success: function success(result) {
+                        success: function (result) {
                             var minData,
                                 delay = 0,
                                 data,
@@ -2303,7 +2388,8 @@ var jQueryShim = require('./jQueryShim');
                             try {
                                 // Remove any keep-alives from the beginning of the result
                                 minData = connection._parseResponse(result);
-                            } catch (error) {
+                            }
+                            catch (error) {
                                 transportLogic.handleParseFailure(instance, result, error, tryFailConnect, instance.pollXhr);
                                 return;
                             }
@@ -2317,9 +2403,10 @@ var jQueryShim = require('./jQueryShim');
                                 data = transportLogic.maximizePersistentResponse(minData);
                             }
 
-                            transportLogic.processMessages(instance, minData, _fireConnect);
+                            transportLogic.processMessages(instance, minData, fireConnect);
 
-                            if (data && $.type(data.LongPollDelay) === "number") {
+                            if (data &&
+                                $.type(data.LongPollDelay) === "number") {
                                 delay = data.LongPollDelay;
                             }
 
@@ -2346,7 +2433,7 @@ var jQueryShim = require('./jQueryShim');
                             }
                         },
 
-                        error: function error(data, textStatus) {
+                        error: function (data, textStatus) {
                             var error = signalR._.transportError(signalR.resources.longPollFailed, connection.transport, data, instance.pollXhr);
 
                             // Stop trying to trigger reconnect, connection is in an error state
@@ -2374,7 +2461,9 @@ var jQueryShim = require('./jQueryShim');
                                 // We check the state here to verify that we're not in an invalid state prior to verifying Reconnect.
                                 // If we're not in connected or reconnecting then the next ensureReconnectingState check will fail and will return.
                                 // Therefore we don't want to change that failure code path.
-                                if ((connection.state === signalR.connectionState.connected || connection.state === signalR.connectionState.reconnecting) && !transportLogic.verifyLastActive(connection)) {
+                                if ((connection.state === signalR.connectionState.connected ||
+                                    connection.state === signalR.connectionState.reconnecting) &&
+                                    !transportLogic.verifyLastActive(connection)) {
                                     return;
                                 }
 
@@ -2399,25 +2488,23 @@ var jQueryShim = require('./jQueryShim');
                         // triggering reconnected.  This depends on the "error" handler of Poll to cancel this
                         // timeout if it triggers before the Reconnected event fires.
                         // The Math.min at the end is to ensure that the reconnect timeout does not overflow.
-                        privateData.reconnectTimeoutId = window.setTimeout(function () {
-                            fireReconnected(instance);
-                        }, Math.min(1000 * (Math.pow(2, reconnectErrors) - 1), maxFireReconnectedTimeout));
+                        privateData.reconnectTimeoutId = window.setTimeout(function () { fireReconnected(instance); }, Math.min(1000 * (Math.pow(2, reconnectErrors) - 1), maxFireReconnectedTimeout));
                     }
-                })(connection);
+                }(connection));
             }, 250); // Have to delay initial poll so Chrome doesn't show loader spinner in tab
         },
 
-        lostConnection: function lostConnection(connection) {
+        lostConnection: function (connection) {
             if (connection.pollXhr) {
                 connection.pollXhr.abort("lostConnection");
             }
         },
 
-        send: function send(connection, data) {
+        send: function (connection, data) {
             transportLogic.ajaxSend(connection, data);
         },
 
-        stop: function stop(connection) {
+        stop: function (connection) {
             /// <summary>Stops the long polling connection</summary>
             /// <param name="connection" type="signalR">The SignalR connection to stop</param>
 
@@ -2434,11 +2521,12 @@ var jQueryShim = require('./jQueryShim');
             }
         },
 
-        abort: function abort(connection, async) {
+        abort: function (connection, async) {
             transportLogic.ajaxAbort(connection, async);
         }
     };
-})(jQueryShim, window);
+
+}(jQueryShim, window));
 /* jquery.signalR.hubs.js */
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
@@ -2469,7 +2557,7 @@ var jQueryShim = require('./jQueryShim');
     }
 
     function getArgValue(a) {
-        return $.isFunction(a) ? null : $.type(a) === "undefined" ? null : a;
+        return $.isFunction(a) ? null : ($.type(a) === "undefined" ? null : a);
     }
 
     function hasMembers(obj) {
@@ -2517,7 +2605,7 @@ var jQueryShim = require('./jQueryShim');
     }
 
     hubProxy.fn = hubProxy.prototype = {
-        init: function init(connection, hubName) {
+        init: function (connection, hubName) {
             this.state = {};
             this.connection = connection;
             this.hubName = hubName;
@@ -2528,11 +2616,11 @@ var jQueryShim = require('./jQueryShim');
 
         constructor: hubProxy,
 
-        hasSubscriptions: function hasSubscriptions() {
+        hasSubscriptions: function () {
             return hasMembers(this._.callbackMap);
         },
 
-        on: function on(eventName, callback) {
+        on: function (eventName, callback) {
             /// <summary>Wires up a callback to be invoked when a invocation request is received from the server hub.</summary>
             /// <param name="eventName" type="String">The name of the hub event to register the callback for.</param>
             /// <param name="callback" type="Function">The callback to be invoked.</param>
@@ -2557,7 +2645,7 @@ var jQueryShim = require('./jQueryShim');
             return that;
         },
 
-        off: function off(eventName, callback) {
+        off: function (eventName, callback) {
             /// <summary>Removes the callback invocation request from the server hub for the given event name.</summary>
             /// <param name="eventName" type="String">The name of the hub event to unregister the callback for.</param>
             /// <param name="callback" type="Function">The callback to be invoked.</param>
@@ -2583,8 +2671,7 @@ var jQueryShim = require('./jQueryShim');
                     if (!hasMembers(callbackSpace)) {
                         delete callbackMap[eventName];
                     }
-                } else if (!callback) {
-                    // Check if we're removing the whole event and we didn't error because of an invalid callback
+                } else if (!callback) { // Check if we're removing the whole event and we didn't error because of an invalid callback
                     $(that).unbind(makeEventName(eventName));
 
                     delete callbackMap[eventName];
@@ -2594,7 +2681,7 @@ var jQueryShim = require('./jQueryShim');
             return that;
         },
 
-        invoke: function invoke(methodName) {
+        invoke: function (methodName) {
             /// <summary>Invokes a server hub method with the given arguments.</summary>
             /// <param name="methodName" type="String">The name of the server hub method.</param>
 
@@ -2604,41 +2691,41 @@ var jQueryShim = require('./jQueryShim');
                 argValues = map(args, getArgValue),
                 data = { H: that.hubName, M: methodName, A: argValues, I: connection._.invocationCallbackId },
                 d = $.Deferred(),
-                callback = function callback(minResult) {
-                var result = that._maximizeHubResponse(minResult),
-                    source,
-                    error;
+                callback = function (minResult) {
+                    var result = that._maximizeHubResponse(minResult),
+                        source,
+                        error;
 
-                // Update the hub state
-                $.extend(that.state, result.State);
+                    // Update the hub state
+                    $.extend(that.state, result.State);
 
-                if (result.Progress) {
-                    if (d.notifyWith) {
-                        // Progress is only supported in jQuery 1.7+
-                        d.notifyWith(that, [result.Progress.Data]);
-                    } else if (!connection._.progressjQueryVersionLogged) {
-                        connection.log("A hub method invocation progress update was received but the version of jQuery in use (" + $.prototype.jquery + ") does not support progress updates. Upgrade to jQuery 1.7+ to receive progress notifications.");
-                        connection._.progressjQueryVersionLogged = true;
+                    if (result.Progress) {
+                        if (d.notifyWith) {
+                            // Progress is only supported in jQuery 1.7+
+                            d.notifyWith(that, [result.Progress.Data]);
+                        } else if(!connection._.progressjQueryVersionLogged) {
+                            connection.log("A hub method invocation progress update was received but the version of jQuery in use (" + $.prototype.jquery + ") does not support progress updates. Upgrade to jQuery 1.7+ to receive progress notifications.");
+                            connection._.progressjQueryVersionLogged = true;
+                        }
+                    } else if (result.Error) {
+                        // Server hub method threw an exception, log it & reject the deferred
+                        if (result.StackTrace) {
+                            connection.log(result.Error + "\n" + result.StackTrace + ".");
+                        }
+
+                        // result.ErrorData is only set if a HubException was thrown
+                        source = result.IsHubException ? "HubException" : "Exception";
+                        error = signalR._.error(result.Error, source);
+                        error.data = result.ErrorData;
+
+                        connection.log(that.hubName + "." + methodName + " failed to execute. Error: " + error.message);
+                        d.rejectWith(that, [error]);
+                    } else {
+                        // Server invocation succeeded, resolve the deferred
+                        connection.log("Invoked " + that.hubName + "." + methodName);
+                        d.resolveWith(that, [result.Result]);
                     }
-                } else if (result.Error) {
-                    // Server hub method threw an exception, log it & reject the deferred
-                    if (result.StackTrace) {
-                        connection.log(result.Error + "\n" + result.StackTrace + ".");
-                    }
-
-                    // result.ErrorData is only set if a HubException was thrown
-                    source = result.IsHubException ? "HubException" : "Exception";
-                    error = signalR._.error(result.Error, source);
-                    error.data = result.ErrorData;
-
-                    connection.log(that.hubName + "." + methodName + " failed to execute. Error: " + error.message);
-                    d.rejectWith(that, [error]);
-                } else {
-                    // Server invocation succeeded, resolve the deferred
-                    connection.log("Invoked " + that.hubName + "." + methodName);
-                    d.resolveWith(that, [result.Result]);
-                }
-            };
+                };
 
             connection._.invocationCallbacks[connection._.invocationCallbackId.toString()] = { scope: that, method: callback };
             connection._.invocationCallbackId += 1;
@@ -2653,7 +2740,7 @@ var jQueryShim = require('./jQueryShim');
             return d.promise();
         },
 
-        _maximizeHubResponse: function _maximizeHubResponse(minHubResponse) {
+        _maximizeHubResponse: function (minHubResponse) {
             return {
                 State: minHubResponse.S,
                 Result: minHubResponse.R,
@@ -2695,10 +2782,10 @@ var jQueryShim = require('./jQueryShim');
 
     hubConnection.fn.init = function (url, options) {
         var settings = {
-            qs: null,
-            logging: false,
-            useDefaultPath: true
-        },
+                qs: null,
+                logging: false,
+                useDefaultPath: true
+            },
             connection = this;
 
         $.extend(settings, options);
@@ -2722,14 +2809,14 @@ var jQueryShim = require('./jQueryShim');
             // We have to handle progress updates first in order to ensure old clients that receive
             // progress updates enter the return value branch and then no-op when they can't find
             // the callback in the map (because the minData.I value will not be a valid callback ID)
-            if (typeof minData.P !== "undefined") {
+            if (typeof (minData.P) !== "undefined") {
                 // Process progress notification
                 dataCallbackId = minData.P.I.toString();
                 callback = connection._.invocationCallbacks[dataCallbackId];
                 if (callback) {
                     callback.method.call(callback.scope, minData);
                 }
-            } else if (typeof minData.I !== "undefined") {
+            } else if (typeof (minData.I) !== "undefined") {
                 // We received the return value from a server method invocation, look up callback by id and call it
                 dataCallbackId = minData.I.toString();
                 callback = connection._.invocationCallbacks[dataCallbackId];
@@ -2858,7 +2945,8 @@ var jQueryShim = require('./jQueryShim');
     hubConnection.fn.init.prototype = hubConnection.fn;
 
     $.hubConnection = hubConnection;
-})(jQueryShim, window);
+
+}(jQueryShim, window));
 /* jquery.signalR.version.js */
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
@@ -2868,7 +2956,7 @@ var jQueryShim = require('./jQueryShim');
 /// <reference path="jquery.signalR.core.js" />
 (function ($, undefined) {
     $.signalR.version = "2.2.1";
-})(jQueryShim);
+}(jQueryShim));
 
-var hubConnection = exports.hubConnection = jQueryShim.hubConnection;
-var signalR = exports.signalR = jQueryShim.signalR;
+export const hubConnection = jQueryShim.hubConnection;
+export const signalR = jQueryShim.signalR;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "description": "Javascript SignalR client without jQuery dependency",
   "dependencies": {
-    "jquery-deferred": "0.3.1"
+    "jquery-deferred": "0.3.1",
+    "jquery-param": "0.2.0"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",

--- a/signalR.js
+++ b/signalR.js
@@ -1308,7 +1308,7 @@ const jQueryShim = require('./jQueryShim');
         getUrl: function (connection, transport, reconnecting, poll, ajaxPost) {
             /// <summary>Gets the url for making a GET based connect request</summary>
             var baseUrl = transport === "webSockets" ? "" : connection.baseUrl,
-                url = baseUrl + connection.url,
+                url = baseUrl + connection.appRelativeUrl,
                 qs = "transport=" + transport;
 
             if (!ajaxPost && connection.groupsToken) {

--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -87,30 +87,18 @@ module.exports = jQueryDeferred.extend(
   jqueryFunction,
   jQueryDeferred,
   {
-<<<<<<< HEAD
-  defaultAjaxHeaders: null,
-  ajax: ajax,
-  inArray: (arr, item) => arr.indexOf(item) !== -1,
-  trim: str => str && str.trim(),
-  isEmptyObject: obj => !obj || Object.keys(obj).length === 0,
-  makeArray: arr => [].slice.call(arr, 0),
-  param: obj => jQueryParam(obj),
-  support: {
-    cors: false
-  }
-});
-=======
     defaultAjaxHeaders: null,
     ajax: ajax,
     inArray: (arr,item) => arr.indexOf(item) !== -1,
     trim: str => str && str.trim(),
     isEmptyObject: obj => !obj || Object.keys(obj).length === 0,
     makeArray: arr => [].slice.call(arr,0),
+    param: obj => jQueryParam(obj),
     support: {
       cors: (function() {
         const xhrObj = xhr();
         return !!xhrObj && ("withCredentials" in xhrObj);
       })()
     }
-  });
->>>>>>> 29ed8725d3985a7b2487bccc277937c327ff3de1
+  })
+  

--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const jQueryDeferred = require('jquery-deferred');
+const jQueryDeferred = require('jquery-deferred')
+const jQueryParam = require('jquery-param')
 
 const jqueryFunction = function(subject) {
   let events = subject.events || {};
@@ -86,6 +87,7 @@ module.exports = jQueryDeferred.extend(
   trim: str => str && str.trim(),
   isEmptyObject: obj => !obj || Object.keys(obj).length === 0,
   makeArray: arr => [].slice.call(arr, 0),
+  param: obj => jQueryParam(obj),
   support: {
     cors: false
   }

--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const jQueryDeferred = require('jquery-deferred')
-const jQueryParam = require('jquery-param')
+const jQueryDeferred = require('jquery-deferred');
+const jQueryParam = require('jquery-param');
 
 const jqueryFunction = function(subject) {
   let events = subject.events || {};

--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -79,8 +79,7 @@ const ajax = function(options) {
       return request.abort(reason);
     },
     xhrSupported: (function() {
-      var xhrSupported = xhr();
-      return !!xhrSupported && ("withCredentials" in xhrSupported);
+      return !!xhr();
     })()
   };  
 };
@@ -96,6 +95,6 @@ module.exports = jQueryDeferred.extend(
     isEmptyObject: obj => !obj || Object.keys(obj).length === 0,
     makeArray: arr => [].slice.call(arr,0),
     support: {
-      cors: ajax.xhrSupported
+      cors: ajax.xhrSupported && ("withCredentials" in xhrSupported);
     }
   });

--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -95,6 +95,6 @@ module.exports = jQueryDeferred.extend(
     isEmptyObject: obj => !obj || Object.keys(obj).length === 0,
     makeArray: arr => [].slice.call(arr,0),
     support: {
-      cors: ajax.xhrSupported && ("withCredentials" in xhrSupported);
+      cors: ajax.xhrSupported && ("withCredentials" in xhrSupported)
     }
   });

--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -50,12 +50,13 @@ const jqueryFunction = function(subject) {
   };
 };
 
+const xhr = function() {
+  try {
+    return new window.XMLHttpRequest();
+  } catch (e) { }
+};
+
 const ajax = function(options) {
-  const xhr = function() {
-    try {
-      return new window.XMLHttpRequest();
-    } catch (e) { }
-  };
   const request = xhr();
   request.onreadystatechange = () => {
     if (request.readyState !== 4) {
@@ -77,12 +78,8 @@ const ajax = function(options) {
   return {
     abort: function(reason) {
       return request.abort(reason);
-    },
-    xhrSupported: (function() {
-      var xhrSupported = xhr();
-      return !!xhrSupported && ("withCredentials" in xhrSupported);
-    })()
-  };  
+    }
+  };
 };
 
 module.exports = jQueryDeferred.extend(
@@ -96,6 +93,9 @@ module.exports = jQueryDeferred.extend(
     isEmptyObject: obj => !obj || Object.keys(obj).length === 0,
     makeArray: arr => [].slice.call(arr,0),
     support: {
-      cors: ajax.xhrSupported
+      cors: (function() {
+        const xhrObj = xhr();
+        return !!xhrObj && ("withCredentials" in xhrObj);
+      })()
     }
   });


### PR DESCRIPTION
This fix adds the "param" method to jQueryShim to prevent errors at signalR.js:1291