### PR TITLE
set 'withCredents' request flag

### DIFF
--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -71,6 +71,7 @@ const ajax = function(options) {
     }
   };
 
+  request.withCredentials = options.xhrFields.withCredentials;
   request.open(options.type, options.url);
   request.setRequestHeader('content-type', options.contentType);
 


### PR DESCRIPTION
This is a bug fix for 'withCredents' XMLHttpRequest flag setting.
Usage example: `this.hub.start({ withCredentials: true });`
Default value: `true`