### PR TITLE
Bugfix: encodeURIComponent when using serverSentEvents

### DIFF
--- a/build/jQueryShim.js
+++ b/build/jQueryShim.js
@@ -79,8 +79,7 @@ var ajax = function ajax(options) {
 
   request.open(options.type, options.url);
   request.setRequestHeader('content-type', options.contentType);
-
-  request.send(options.data.data && 'data=' + options.data.data);
+  request.send(options.data.data && 'data=' + encodeURIComponent(options.data.data));
 
   return {
     abort: function abort(reason) {

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
   "scripts": {
     "build": "babel src --presets babel-preset-es2015 --out-dir build"
   },
-  "version": "0.1.8"
+  "version": "0.1.9"
 }

--- a/src/jQueryShim.js
+++ b/src/jQueryShim.js
@@ -73,8 +73,7 @@ const ajax = function(options) {
 
   request.open(options.type, options.url);
   request.setRequestHeader('content-type', options.contentType);
-
-  request.send(options.data.data && `data=${options.data.data}`);
+  request.send(options.data.data && `data=${encodeURIComponent(options.data.data)}`);
 
   return {
     abort: function(reason) {


### PR DESCRIPTION
serverSentEvents uses content type: application/x-www-form-urlencoded

The data passed needs to be encoded. Otherwise, reserved characters like '+', '&', '=' will cause problems.